### PR TITLE
Support QualifiedDo for GHC>=9.0.1

### DIFF
--- a/Control/Monad/Indexed.hs
+++ b/Control/Monad/Indexed.hs
@@ -16,6 +16,7 @@ module Control.Monad.Indexed
   , IxMonad(..)
   , IxMonadZero(..)
   , IxMonadPlus(..)
+  , IxMonadFail(..)
   , ijoin, (>>>=), (=<<<)
   , iapIxMonad
   ) where
@@ -45,3 +46,6 @@ class IxMonad m => IxMonadZero m where
 
 class IxMonadZero m => IxMonadPlus m where
   implus :: m i j a -> m i j a -> m i j a
+
+class IxMonad m => IxMonadFail m where
+  ifail :: String -> m i i a

--- a/Control/Monad/Indexed.hs
+++ b/Control/Monad/Indexed.hs
@@ -16,7 +16,6 @@ module Control.Monad.Indexed
   , IxMonad(..)
   , IxMonadZero(..)
   , IxMonadPlus(..)
-  , IxMonadFail(..)
   , ijoin, (>>>=), (=<<<)
   , iapIxMonad
   ) where
@@ -46,6 +45,3 @@ class IxMonad m => IxMonadZero m where
 
 class IxMonadZero m => IxMonadPlus m where
   implus :: m i j a -> m i j a -> m i j a
-
-class IxMonad m => IxMonadFail m where
-  ifail :: String -> m i i a

--- a/Control/Monad/Indexed/Fail.hs
+++ b/Control/Monad/Indexed/Fail.hs
@@ -1,3 +1,14 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Indexed.Fail
+-- Copyright   :  (C) 2025 Rinse
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :
+-- Stability   :  experimental
+-- Portability :  portable
+--
+----------------------------------------------------------------------------
 module Control.Monad.Indexed.Fail
   ( IxMonadFail(..)
   ) where

--- a/Control/Monad/Indexed/Fail.hs
+++ b/Control/Monad/Indexed/Fail.hs
@@ -1,0 +1,8 @@
+module Control.Monad.Indexed.Fail
+  ( IxMonadFail(..)
+  ) where
+
+import Control.Monad.Indexed
+
+class IxMonad m => IxMonadFail m where
+  ifail :: String -> m i i a

--- a/Control/Monad/Indexed/QualifiedDo.hs
+++ b/Control/Monad/Indexed/QualifiedDo.hs
@@ -1,0 +1,47 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Indexed.QualifiedDo
+-- Copyright   :  (C) 2025 Rinse
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :
+-- Stability   :  experimental
+-- Portability :  portable
+--
+----------------------------------------------------------------------------
+module Control.Monad.Indexed.QualifiedDo
+  ( (>>=), (>>), return, fail
+  , fmap, (<*>), join, mfix
+  ) where
+
+import           Control.Monad.Indexed
+import           Control.Monad.Indexed.Fix
+import qualified Prelude
+
+infixl 1 >>=, >>
+
+(>>=) :: IxMonad m => m i j a -> (a -> m j k b) -> m i k b
+m >>= f = ibind f m
+
+(>>) :: IxMonad m => m i j a -> m j k b -> m i k b
+m >> n = m >>= \_ -> n
+
+return :: IxPointed m => a -> m i i a
+return = ireturn
+
+fail :: IxMonadFail m => Prelude.String -> m i i a
+fail = ifail
+
+fmap :: IxFunctor f => (a -> b) -> f j k a -> f j k b
+fmap = imap
+
+infixl 4 <*>
+
+(<*>) :: IxApplicative m => m i j (a -> b) -> m j k a -> m i k b
+(<*>) = iap
+
+join :: IxMonad m => m i j (m j k a) -> m i k a
+join = ijoin
+
+mfix :: IxMonadFix m => (a -> m i i a) -> m i i a
+mfix = imfix

--- a/Control/Monad/Indexed/QualifiedDo.hs
+++ b/Control/Monad/Indexed/QualifiedDo.hs
@@ -15,6 +15,7 @@ module Control.Monad.Indexed.QualifiedDo
   ) where
 
 import           Control.Monad.Indexed
+import           Control.Monad.Indexed.Fail
 import           Control.Monad.Indexed.Fix
 import qualified Prelude
 

--- a/indexed.cabal
+++ b/indexed.cabal
@@ -26,7 +26,8 @@ Library
     Data.Functor.Indexed, 
     Control.Monad.Indexed, 
     Control.Monad.Indexed.Fix, 
-    Control.Monad.Indexed.Trans
+    Control.Monad.Indexed.Trans,
+    Control.Monad.Indexed.QualifiedDo
     Control.Comonad.Indexed
  default-language: Haskell98
  if impl(ghc >= 7.5)

--- a/indexed.cabal
+++ b/indexed.cabal
@@ -25,9 +25,10 @@ Library
   Exposed-modules:     
     Data.Functor.Indexed, 
     Control.Monad.Indexed, 
+    Control.Monad.Indexed.Fail,
     Control.Monad.Indexed.Fix, 
-    Control.Monad.Indexed.Trans,
-    Control.Monad.Indexed.QualifiedDo
+    Control.Monad.Indexed.QualifiedDo,
+    Control.Monad.Indexed.Trans
     Control.Comonad.Indexed
  default-language: Haskell98
  if impl(ghc >= 7.5)


### PR DESCRIPTION
Support for `-XQualifiedDo` has been added in GHC versions >= 9.0.1.

The new module `Control.Monad/Indexed/QualifiedDo` provides the following functions:

- `>>=`, `>>`, and `fail` for monadic operations.
- `fmap`, `<*>`, and `join` to ensure compatibility with `-XApplicativeDo`.
- `mfix` and `return` to ensure compatibility with `-XRecursiveDo`.

Additionally, a new typeclass, `IxMonadFail`, has been introduced in `Control/Monad/Indexed/Fail` to support `fail`.

The naming of the functions is based on the documentation:
https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/qualified_do.html

I left the maintainer field blank but I’m ready to fill it with a specific name. Please inform me of the name you would like to use.